### PR TITLE
fix(router): mount public catalog route at root level (404 bug)

### DIFF
--- a/router/bin/server.dart
+++ b/router/bin/server.dart
@@ -85,6 +85,11 @@ final _router = Router()
     (Request req, String type, String id) =>
         _userStreamHandler(req, 'public', type, id),
   )
+  ..get(
+    '/catalog/<type>/<id>.json',
+    (Request req, String type, String id) =>
+        addonService.handleCatalog(req, type, id),
+  ) // Public catalog (proxies Cinemeta)
   ..get('/api/status', _rootHandler) // Moved to free up root for portal
   ..get('/dl/<file>', _handleDownload)
   ..get(

--- a/router/lib/addon_service.dart
+++ b/router/lib/addon_service.dart
@@ -42,7 +42,7 @@ class AddonService {
     app.get('/u/<userId>/manifest.json', _handleUserManifest);
 
     // Catalog Handler (Public)
-    app.get('/catalog/<type>/<id>.json', _handleCatalog);
+    app.get('/catalog/<type>/<id>.json', handleCatalog);
 
     return app;
   }
@@ -93,7 +93,7 @@ class AddonService {
   }
 
   /// Handler for catalog requests (Popular content).
-  Future<Response> _handleCatalog(Request req, String type, String id) async {
+  Future<Response> handleCatalog(Request req, String type, String id) async {
     // Check for Dynamic Catalog
     if (id.startsWith('dynamic:')) {
       final parts = id.split(':');


### PR DESCRIPTION
## Problem

The `/catalog/<type>/<id>.json` route was defined inside `AddonService.router` but that sub-router was **never mounted** in the main Shelf pipeline in `server.dart`. This caused **all catalog requests to return 404**, meaning Stremio showed no popular movies/series content.

## Root Cause

`AddonService` exposes a `.router` getter (used for route declarations internally) but `server.dart` only uses `addonService` for manifest generation and stream resolution — the `.router` itself was never mounted with `..mount()`.

## Fix

- Renamed `_handleCatalog` → `handleCatalog` (public) in `AddonService`
- Added `/catalog/<type>/<id>.json` to the global `_router` in `server.dart`, delegating to `addonService.handleCatalog`

## Verification

Tested against live local server:
- `GET /catalog/movie/top.json` → ✅ 47 movies (Cinemeta proxy)
- `GET /catalog/series/top.json` → ✅ 50 series (Cinemeta proxy)
- `GET /manifest.json` → ✅ correct manifest with CORS
- `GET /stream/movie/tt0120338.json` → ✅ graceful Gardener disconnected message
- Stremio Web install URL (`?addon=http://...`) → ✅ manifest fetched successfully

All endpoints verified with `Access-Control-Allow-Origin: *` CORS header for Stremio web compatibility.